### PR TITLE
Add Windows gamedata for Team Fortress 2

### DIFF
--- a/gamedata/tickbase-manipulation-fix.games.txt
+++ b/gamedata/tickbase-manipulation-fix.games.txt
@@ -38,4 +38,14 @@
             }
         }
 	}
+	"tf"
+	{
+		"Signatures"
+		{
+			"CPlayerMove::RunCommand"
+			{
+				"windows"		"\x55\x8B\xEC\x83\xEC\x1C\x56\x57\x8B\x7D\x08\x89\x4D\xFC\x8B\xB7\x2A\x08\x00\x00"
+			}
+		}
+	}
 }


### PR DESCRIPTION
Signature contains xref string "sv_maxusrcmdprocessticks_warning at server tick %u:".

Confirmed successful load on TF2 Win / Linux; I don't have a way to test its functionality.